### PR TITLE
Tasks imported into Time 2 same order as OmniFocus

### DIFF
--- a/omni2tyme.osascript
+++ b/omni2tyme.osascript
@@ -2,7 +2,7 @@ activate "OmniFocus"
 tell application "OmniFocus"
 	tell front window
 		set my_sel to selected trees of content
-		repeat with ptaskt in my_sel
+		repeat with ptaskt in reverse of my_sel
 			set ptask to value of ptaskt
 			set ftask to flattened tasks of ptask
 			set haschild to false


### PR DESCRIPTION
This fixed the following issues:

If I select multiple tasks in OmniFocus and run the omni2tyme script, they always come in reverse order. So if they are in omnifocus as:

task1
task2
task3

, they go into Tyme 2 as:

task3
task2
task1